### PR TITLE
Update --prod arguments, no longer valid in Angular 12+

### DIFF
--- a/vsu-app/vsu-app.csproj
+++ b/vsu-app/vsu-app.csproj
@@ -54,10 +54,10 @@
     <Target Name="PublishRunWebpack" AfterTargets="ComputeFilesToPublish">
         <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
         <Exec WorkingDirectory="$(SpaRoot)" Command="npm install" />
-        <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --prod" />
+        <Exec WorkingDirectory="$(SpaRoot)" Command="npm run build -- --configuration production" />
         <Exec
             WorkingDirectory="$(SpaRoot)"
-            Command="npm run build:ssr -- --prod"
+            Command="npm run build:ssr -- --configuration production"
             Condition=" '$(BuildServerSideRenderer)' == 'true' "
         />
         <!-- Include the newly-built files in the publish output -->


### PR DESCRIPTION
# Description

--prod argument is no longer valid in Angular 12+ (including Angular 16+).  Replaced for --configuration production instead.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
